### PR TITLE
GG6 Fix Conductor Class

### DIFF
--- a/Conductor.cs
+++ b/Conductor.cs
@@ -5,14 +5,11 @@ using UnityEngine;
 public class Conductor : MonoBehaviour
 {
     public bool isConducting;
-    public int sequenceCounter = 0;
+    public bool isPlaying;
+    public List<string> ghostSong;
 
     private Dictionary<string, Ghost> ghostDict = new Dictionary<string, Ghost>();
     private List<string> ghostIds;
-    private List<string> ghostSong;
-
-    private int i = 1;
-    private int randomNum;
 
     // Start is called before the first frame update
     void Start()
@@ -29,31 +26,29 @@ public class Conductor : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        // We are looping by frame.  Originally I was looping by sequence but I think that may lead to bugs if the frames and loop get out of sync
-        if(isConducting)
+        bool play = isConducting && !isPlaying;
+        if(play)
         {
-            if(i < sequenceCounter)
-            {
-                randomNum = Random.Range(0, 4);
-                string ghostId = ghostIds[randomNum];
-                ghostSong.Add(ghostId);
-
-                Ghost activeGhost = ghostDict[ghostId];
-                activeGhost.activate();
-                StartCoroutine(waiter());
-                i++;
-            }
-            else
-            {
-                isConducting = false;
-                sequenceCounter++;
-            }
+            StartCoroutine(playGhostSong());
         }
     }
 
-    IEnumerator waiter()
+    IEnumerator playGhostSong()
     {
-        yield return new WaitForSeconds(0.5f);
+        isPlaying = true;
+        int randomNum = Random.Range(0, 4);
+        string ghostId = ghostIds[randomNum];
+        ghostSong.Add(ghostId);
+
+        foreach (string id in ghostSong)
+        {
+            Ghost activeGhost = ghostDict[id];
+            activeGhost.activate();
+            yield return new WaitForSeconds(0.5f);
+        }
+
+        isConducting = false;
+        isPlaying = false;
     }
 
 

--- a/Judge.cs
+++ b/Judge.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Judge : MonoBehaviour
+{
+    Conductor conductor;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        conductor = GetComponent<Conductor>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if(!conductor.isConducting)
+        {
+            int songLength = conductor.ghostSong.Count;
+        }
+    }
+}

--- a/Judge.cs.meta
+++ b/Judge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: deb3586cb007c8642975aa36becaaa84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The Conductor class was thrown together quickly in the initial commit.  I didn't think to far ahead nor did I test it too much.  In this branch however, I spent time testing and tweaking how Conductor works.  Some major issues that were solved:
1) the `sequenceCounter` and `i` variables were completely unnecessary and were causing a major bug.  In the initial commit, I was thinking that each new round would generate a brand new sequence which is **not** how simon says works.  We need to build upon the last played note.  For example, the game should look something like this - `C`, `CB`, `CBG`, etc.
2) the Coroutine that paused after each activated ghost was not working properly because all the work was being done in the update method.  I read in [this post](https://forum.unity.com/threads/return-yield-new-waitforseconds-not-working.417946/) that this is expected as the update method is a different Coroutine.  "it's timing won't affect the other Coroutines."  This was an easy fix, I just offloaded all the work to the Coroutine that contained the wait logic.
3) There needed to be a boolean that flagged when the sequence was being played.  
    - `isConducting` will be used to trigger when we want the sequence to start.  This boolean will also prevent the player from interacting with the ghosts when the conductor is showing them the sequence they must copy.  
    - `isPlaying` was added so that the Conductor knows that it's in the middle of playing the sequence.  If this boolean is not present, the conductor will be in an infinite loop (until `isConducting` is turned off), rapidly stepping on it's own toes as it tries to simultaneously finish presenting `sequence a` while starting `sequence a2`