### PR TITLE
Implemented a basic start menu

### DIFF
--- a/GameCoordinator.cs
+++ b/GameCoordinator.cs
@@ -1,18 +1,64 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class GameCoordinator : MonoBehaviour
 {
+    public GameObject startMenu;
+    public GameObject game;
+    public int countDown;
+
+    public bool activateGame;
+
     // Start is called before the first frame update
     void Start()
     {
-        
+        activateStartMenu();
+        countDown = 2;
     }
 
     // Update is called once per frame
     void Update()
     {
-        
+        monitorStartMenuInput();
+
     }
+
+    void activateStartMenu()
+    {
+        startMenu.SetActive(true);
+        game.SetActive(false);
+    }
+
+    void monitorStartMenuInput()
+    {
+
+        if(activateGame)
+        {
+            startGame();
+        }
+        else
+        {
+            countDown = 2;
+            activateStartMenu();
+        }
+    }
+
+    void startGame()
+    {
+        startMenu.SetActive(false);
+        game.SetActive(true);
+        StartCoroutine(countDownLoop());
+    }
+
+
+    IEnumerator countDownLoop()
+    {
+        int i = 0;
+        if (i <= countDown)
+        {
+            countDown -= i;
+        }
+       yield return new WaitForSeconds(0.5f);
+    }
+
 }

--- a/MenuButton.cs
+++ b/MenuButton.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class MenuButton : MonoBehaviour
+{
+    public string name;
+    public bool isActive;
+
+    private Image highlight;
+
+    private void Start()
+    {
+        highlight = GetComponent<Image>();
+        highlight.enabled = false;
+    }
+
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.name == "Player")
+        {
+            isActive = true;
+            highlight.enabled = true;
+        }
+    }
+
+    private void OnTriggerExit2D(Collider2D collision)
+    {
+        if (collision.name == "Player")
+        {
+            isActive = false;
+            highlight.enabled = false;
+        }
+    }
+}

--- a/MenuButton.cs.meta
+++ b/MenuButton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8fb638ebd2523f445b654ba1684ca7ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/StartMenu.cs
+++ b/StartMenu.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class StartMenu : MonoBehaviour
+{
+    public GameObject menuOptions;
+    public GameObject gameCoordinatorObject;
+
+    private Dictionary<string, MenuButton> buttons = new Dictionary<string, MenuButton>();
+    private GameCoordinator gameCoordinator;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        getButtons();
+        gameCoordinator = gameCoordinatorObject.GetComponent<GameCoordinator>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+
+        if (buttons["start"].isActive)
+        {
+            activateStart();
+        }
+        else if (buttons["options"].isActive)
+        {
+            activateOption();
+        }
+        else if (buttons["exit"].isActive)
+        {
+            activateExit();
+        }
+    }
+    
+
+    void getButtons()
+    {
+        foreach(Transform child in menuOptions.transform)
+        {
+            if(child.tag == "button")
+            {
+                MenuButton button = child.GetComponent<MenuButton>();
+                buttons[button.name] = button;
+            }
+        }
+    }
+
+
+    void activateStart()
+    {
+        if (Input.GetMouseButton(0))
+        {
+            gameCoordinator.activateGame = true;
+        }
+    }
+
+    void activateOption()
+    {
+        if (Input.GetMouseButton(0))
+        {
+            return;
+        }
+    }
+
+    void activateExit()
+    {
+        if (Input.GetMouseButton(0))
+        {
+            return;
+        }
+    }
+}

--- a/StartMenu.cs.meta
+++ b/StartMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1f6f72c8ae862246aa1af738792b667
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
In this pull request I added a basic start menu.  The only button that currently does anything is the "start" button.  The game will begin at the start menu, and once the start button is pressed, the player will be brought to the game window.  

The script GameCoordinator was added to handle the menu and game interaction.  Eventually I think this script will also be the bridge between the conductor and player input.  